### PR TITLE
AUI-1363 - Make aui-redo accessible

### DIFF
--- a/demos/undo-redo/index.html
+++ b/demos/undo-redo/index.html
@@ -91,6 +91,8 @@
             undoRedo.set('queueable', !undoRedo.get('queueable'));
         });
 
+        undoRedo.bindShortcuts('body');
+
         function boxSetXY(xy) {
             box.setXY(xy);
             previousXY = xy;

--- a/demos/undo-redo/index.html
+++ b/demos/undo-redo/index.html
@@ -51,7 +51,13 @@
     YUI({filter: 'raw'}).use('aui-undo-redo', 'dd-drag', 'dd-constrain', function(Y) {
         var box = Y.one('#redbox'),
             dd = new Y.DD.Drag({node: '#redbox'}),
-            undoRedo = new Y.UndoRedo(),
+            undoRedo = new Y.UndoRedo(
+                {
+                    shortcutConfig: {
+                        bindShortcutsTo: 'body'
+                    }
+                }
+            ),
             previousXY = box.getXY(),
             async = false;
 
@@ -90,8 +96,6 @@
         Y.one('input[type=checkbox]').on('change', function() {
             undoRedo.set('queueable', !undoRedo.get('queueable'));
         });
-
-        undoRedo.bindShortcuts('body');
 
         function boxSetXY(xy) {
             box.setXY(xy);

--- a/src/aui-base/js/aui-loader.js
+++ b/src/aui-base/js/aui-loader.js
@@ -1319,6 +1319,7 @@ Y.mix(YUI.Env[Y.version].modules, {
         "requires": [
             "base",
             "base-build",
+            "event-key",
             "promise"
         ]
     },
@@ -1399,4 +1400,4 @@ Y.mix(YUI.Env[Y.version].modules, {
         ]
     }
 });
-YUI.Env[Y.version].md5 = '1d9b51f674b35ebcaadf149c02b0afec';
+YUI.Env[Y.version].md5 = 'a13acc711d72f9d90460deb31694d301';

--- a/src/aui-base/js/aui-loader.json
+++ b/src/aui-base/js/aui-loader.json
@@ -1293,6 +1293,7 @@
         "requires": [
             "base",
             "base-build",
+            "event-key",
             "promise"
         ]
     },

--- a/src/aui-undo-redo/HISTORY.md
+++ b/src/aui-undo-redo/HISTORY.md
@@ -1,2 +1,9 @@
-aui-undo-redo
-========
+# AUI Undo-Redo
+
+## @VERSION@
+
+No registries yet
+
+## [3.0.0pr2](https://github.com/liferay/alloy-ui/releases/tag/3.0.0pr2)
+
+* [AUI-1363](https://issues.liferay.com/browse/AUI-1363) Make aui-redo accessible

--- a/src/aui-undo-redo/js/aui-undo-redo.js
+++ b/src/aui-undo-redo/js/aui-undo-redo.js
@@ -130,6 +130,16 @@ A.UndoRedo = A.Base.create('undo-redo', A.Base, [], {
     },
 
     /**
+     * Binds keyboard shortcuts to a given DOM node
+     *
+     * @method bindShortcuts
+     * @param {String | Node} node to bind shortcuts to.
+     */
+    bindShortcuts: function(node) {
+        A.one(node).on('keypress', this._handleKeypress, this);
+    },
+
+    /**
      * Checks if it's possible to redo an action.
      *
      * @method canRedo
@@ -266,6 +276,26 @@ A.UndoRedo = A.Base.create('undo-redo', A.Base, [], {
         }
         else {
             this._afterAction(action);
+        }
+    },
+
+    /**
+     * Receives keyboard input.
+     *
+     * @method _handleKeypress
+     * @param {event} event
+     * @protected
+     */
+    _handleKeypress: function(event) {
+        var keyCode = event.keyCode;
+
+        if (event.ctrlKey) {
+            if (keyCode === 26) {
+                this.undo();
+            }
+            else if (keyCode === 9) {
+                this.redo();
+            }
         }
     },
 

--- a/src/aui-undo-redo/js/aui-undo-redo.js
+++ b/src/aui-undo-redo/js/aui-undo-redo.js
@@ -139,7 +139,7 @@ A.UndoRedo = A.Base.create('undo-redo', A.Base, [], {
      */
     bindShortcuts: function(config) {
         if (!config) {
-            config = this.get('config');
+            config = this.get('shortcutConfig');
         }
 
         if (config.bindShortcutsTo) {

--- a/src/aui-undo-redo/js/aui-undo-redo.js
+++ b/src/aui-undo-redo/js/aui-undo-redo.js
@@ -137,14 +137,15 @@ A.UndoRedo = A.Base.create('undo-redo', A.Base, [], {
      * @method bindShortcuts
      * @param {String | Node} node to bind shortcuts to.
      */
-    bindShortcuts: function(shortcutConfig) {
-        if (!shortcutConfig) {
-            shortcutConfig = this.get('shortcutConfig');
+    bindShortcuts: function(config) {
+        if (!config) {
+            config = this.get('config');
         }
 
-        if (shortcutConfig.bindShortcutsTo) {
-            A.one(shortcutConfig.bindShortcutsTo).on('key', this._handleKeypress,
-                shortcutConfig.type + ':' + shortcutConfig.undoKeyCode + ',' + shortcutConfig.redoKeyCode + '+' + shortcutConfig.modifier, this);
+        if (config.bindShortcutsTo) {
+            A.one(config.bindShortcutsTo).on('key', this._handleKeypress,
+                config.type + ':' + config.undoKeyCode + ',' +
+                config.redoKeyCode + '+' + config.modifier, this);
         }
     },
 
@@ -297,12 +298,12 @@ A.UndoRedo = A.Base.create('undo-redo', A.Base, [], {
      */
     _handleKeypress: function(event) {
         var keyCode = event.keyCode,
-            shortcutConfig = this.get('shortcutConfig');
+            config = this.get('shortcutConfig');
 
-        if (keyCode === shortcutConfig.undoKeyCode) {
+        if (keyCode === config.undoKeyCode) {
             this.undo();
         }
-        else if (keyCode === shortcutConfig.redoKeyCode) {
+        else if (keyCode === config.redoKeyCode) {
             this.redo();
         }
     },

--- a/src/aui-undo-redo/meta/aui-undo-redo.json
+++ b/src/aui-undo-redo/meta/aui-undo-redo.json
@@ -3,6 +3,7 @@
         "requires": [
             "base",
             "base-build",
+            "event-key",
             "promise"
         ]
     }


### PR DESCRIPTION
Hi @drewbrokke,

This one is working great.  But now I think we need to abstract out the accessibility logic into its' own file.  @Robert-Frampton recommended we use aui-modal-resize as an example for an augmentation class.  I think we could call ours aui-undo-redo-accessibility.   And once we do that, we also need to write a test case/cases.  Could you tackle these when you get a chance?

Please let me know if there are any issues.

Thanks! 
